### PR TITLE
topmost() is deprecated. Use Frame.topmost()

### DIFF
--- a/src/rater.ios.ts
+++ b/src/rater.ios.ts
@@ -1,8 +1,8 @@
 import {AppRaterBase, AppRaterConfigs, defaultConfigs} from './rater.common';
-import {topmost} from 'tns-core-modules/ui/frame';
+import {Frame} from 'tns-core-modules/ui/frame';
 
 function currentViewController(): any {
-    let vc = topmost().ios.controller;
+    let vc = Frame.topmost().ios.controller;
     let page = null;
     while (vc.presentedViewController
         && vc.presentedViewController.viewLoaded) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
A console warning on iOS about topmost beint deprecated

## What is the new behavior?
No longer a console warning for iOS

Fixes #[9].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

