### PR TITLE
chore: switch compile to implementation

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -8,5 +8,5 @@ dependencies {
     // Describe plugin native Android dependencies like
 	// compile "groupName:pluginName:ver" 
     // EXAMPLE: compile "com.facebook.fresco:fresco:0.9.0+"
-    compile "com.github.hotchemi:android-rate:1.0.1"
+    implementation "com.github.hotchemi:android-rate:1.0.1"
 }


### PR DESCRIPTION
compile is obsolete so it throws a build error.
Switching it to implementation has no side effects.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] All existing tests are passing

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Plugin throws a build error in newer Android gradle version.

## What is the new behavior?
<!-- Describe the changes. -->
Plugin builds correctly
